### PR TITLE
Allows asNavFor to apply to multiple slicks

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -337,9 +337,9 @@
     };
 
     Slick.prototype.asNavFor = function(index) {
-        var _ = this,
-            asNavFor = _.options.asNavFor !== null ? $(_.options.asNavFor).slick('getSlick') : null;
-        if (asNavFor !== null) asNavFor.slideHandler(index, true);
+        $( this.options.asNavFor ).not( $(this) ).each(function(){
+            $(this).slick('getSlick').slideHandler(index,true);
+        });
     };
 
     Slick.prototype.applyTransition = function(slide) {


### PR DESCRIPTION
Changes the asNavFor function to allow one slick instance to control multiple instances. It excludes itself from the list to avoid an endless loop situation. 

The function doesn't test for null explicitly anymore, as passing null to jQuery will result in a no-op anyway. If this.options.asNavFor is a valid jQuery selector, it will run slideHandler() on each instance of slick that it finds on each matching node that jQuery finds.
